### PR TITLE
CVE-2025-58181: fix vendor crypto/ssh

### DIFF
--- a/vendor/golang.org/x/crypto/ssh/ssh_gss.go
+++ b/vendor/golang.org/x/crypto/ssh/ssh_gss.go
@@ -106,6 +106,13 @@ func parseGSSAPIPayload(payload []byte) (*userAuthRequestGSSAPI, error) {
 	if !ok {
 		return nil, errors.New("parse uint32 failed")
 	}
+	// Each ASN.1 encoded OID must have a minimum
+	// of 2 bytes; 64 maximum mechanisms is an
+	// arbitrary, but reasonable ceiling.
+	const maxMechs = 64
+	if n > maxMechs || int(n)*2 > len(rest) {
+		return nil, errors.New("invalid mechanism count")
+	}
 	s := &userAuthRequestGSSAPI{
 		N:    n,
 		OIDS: make([]asn1.ObjectIdentifier, n),
@@ -122,7 +129,6 @@ func parseGSSAPIPayload(payload []byte) (*userAuthRequestGSSAPI, error) {
 		if rest, err = asn1.Unmarshal(desiredMech, &s.OIDS[i]); err != nil {
 			return nil, err
 		}
-
 	}
 	return s, nil
 }


### PR DESCRIPTION
curb GSSAPI DoS risk by limiting number of specified OIDS

Previously, an attacker could specify an integer up to 0xFFFFFFFF that would directly allocate memory despite the observability of the rest of the payload. This change places a hard cap on the amount of mechanisms that can be specified and encoded in the payload. Additionally, it performs a small sanity check to deny payloads whose stated size is contradictory to the observed payload.

Thank you to Jakub Ciolek for reporting this issue.

Fixes CVE-2025-58181
Fixes golang/go#76363

Change-Id: I0307ab3e906a3f2ae763b5f9f0310f7073f84485
Reviewed-on: https://go-review.googlesource.com/c/crypto/+/721961
Auto-Submit: Roland Shoemaker <roland@golang.org>
Reviewed-by: Damien Neil <dneil@google.com>
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>

[vlefebvre: Adapt for SUSE-v28.5.1]

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

