### PR TITLE
CVE-2026-33748: Fix git: normalize and validate subdir paths

### DIFF
--- a/vendor/github.com/moby/buildkit/source/git/gitsource.go
+++ b/vendor/github.com/moby/buildkit/source/git/gitsource.go
@@ -486,7 +486,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		}
 	}()
 
-	subdir := path.Clean(gs.src.Subdir)
+	subdir := path.Join("/", gs.src.Subdir)
 	if subdir == "/" {
 		subdir = "."
 	}
@@ -559,6 +559,11 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 			return nil, errors.Wrapf(err, "failed to checkout remote %s", urlutil.RedactCredentials(gs.src.Remote))
 		}
 		if subdir != "." {
+			subdir = filepath.FromSlash(subdir)
+			if err := validateDirsOnly(cd, subdir); err != nil {
+				return nil, errors.Wrapf(err, "invalid subdir %v", subdir)
+			}
+
 			d, err := os.Open(filepath.Join(cd, subdir))
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to open subdir %v", subdir)
@@ -760,4 +765,28 @@ func (md cacheRefMetadata) setGitSnapshot(key string) error {
 
 func (md cacheRefMetadata) setGitRemote(key string) error {
 	return md.SetString(keyGitRemote, key, gitRemoteIndex+key)
+}
+
+// validateDirsOnly checks that the given subpath in the repository
+// only contains directories without any symlinks or files.
+func validateDirsOnly(root string, subpath string) error {
+	rel := filepath.Clean(subpath)
+	rel = strings.TrimPrefix(rel, string(filepath.Separator))
+	if rel == "" || rel == "." {
+		return nil
+	}
+
+	p := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		p = filepath.Join(p, part)
+
+		fi, err := os.Lstat(p)
+		if err != nil {
+			return errors.Wrapf(err, "failed to lstat %q", p)
+		}
+		if !fi.IsDir() {
+			return errors.Errorf("git subpath %q contains non-directory %q", subpath, p)
+		}
+	}
+	return nil
 }

--- a/vendor/github.com/moby/buildkit/source/gitidentifier.go
+++ b/vendor/github.com/moby/buildkit/source/gitidentifier.go
@@ -47,9 +47,6 @@ func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 		u.Fragment = ""
 		repo.Remote = u.String()
 	}
-	if sd := path.Clean(repo.Subdir); sd == "/" || sd == "." {
-		repo.Subdir = ""
-	}
 	return &repo, nil
 }
 
@@ -72,5 +69,7 @@ func getRefAndSubdir(fragment string) (ref string, subdir string) {
 	if len(refAndDir) > 1 && len(refAndDir[1]) != 0 {
 		subdir = refAndDir[1]
 	}
+	subdir = path.Join("/", subdir)
+	subdir = strings.TrimPrefix(subdir, "/")
 	return
 }


### PR DESCRIPTION
CVE-2026-33748

Insufficient validation of Git URL fragment subdir components (<url>#<ref>:<subdir>, docs) may allow access to files outside the checked-out Git repository root. Possible access is limited to files on the same mounted filesystem.

Fix: Normalize Git subdir fragments and validate checkout subdir components so each segment must be a real directory, preventing traversal and symlink escapes.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit 8c994eb561a2646b35352e5663afecd225306214) (cherry picked from commit f756b3f8aa2f32b0986c1cbb6449a29fe22715d7)

Reference: https://github.com/moby/buildkit/commit/45b038cd0b2ec2d34013ce0f085522276f7ee0d8

Fixes CVE-2026-33748
Fixes bsc#1261078

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

